### PR TITLE
Dynamically assign the IP and hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ VIP Go Quickstart is a local development environment for developers creating and
 
 ## Installation
 
+0. Networking requires Zeroconf:
+	* OS X: You already have Zeroconf, nothing to do here!
+	* Windows: If you have iTunes, you already have this. Otherwise, you need to install [Bonjour](http://support.apple.com/kb/DL999)
+	* Ubuntu: Run the following command `sudo apt-get install avahi-dnsconfd`
 1. Clone this repository to your local machine
 2. Move to VIP Go Quickstart directory
 3. Start the Vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@
 Vagrant.configure(2) do |config|
   config.vm.box = "ubuntu/trusty64"
   # todo: check the resultant hostname is valid, e.g. no spaces
-  config.vm.hostname = File.basename( File.dirname(__FILE__) ) + "-vip.local"
+  config.vm.hostname = File.basename( File.dirname(__FILE__) ) + "-vip-go.local"
   config.vm.network "private_network", type: "dhcp"
 
   # define is_windows used for determining whether we should or not use nfs

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@
 Vagrant.configure(2) do |config|
   config.vm.box = "ubuntu/trusty64"
   config.vm.hostname = "vip.local"
-  config.vm.network :private_network, ip: "10.86.73.80"
+  config.vm.network "private_network", type: "dhcp"
 
 # define is_windows used for determinig whether we should or not use nfs
 # todo: use samba for windows?

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@
 Vagrant.configure(2) do |config|
   config.vm.box = "ubuntu/trusty64"
   # todo: check the resultant hostname is valid, e.g. no spaces
-  config.vm.hostname = File.basename( File.dirname(__FILE__) ) + ".vip.local"
+  config.vm.hostname = File.basename( File.dirname(__FILE__) ) + "-vip.local"
   config.vm.network "private_network", type: "dhcp"
 
   # define is_windows used for determining whether we should or not use nfs

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,14 +3,15 @@
 
 Vagrant.configure(2) do |config|
   config.vm.box = "ubuntu/trusty64"
-  # todo: check the resultant hostname is valid, e.g. no spaces
+  # TODO: check the resultant hostname is valid, e.g. no spaces
   config.vm.hostname = File.basename( File.dirname(__FILE__) ) + "-vip-go.local"
   config.vm.network "private_network", type: "dhcp"
 
-  # define is_windows used for determining whether we should or not use nfs
-  # todo: use samba for windows?
+  # Define is_windows used for determining whether we should or not use NFS
   is_windows = RUBY_PLATFORM.downcase.include?("w32");
+  # TODO: How to identify Ubuntu? 
 
+  # TODO: use Samba for Windows?
   config.vm.synced_folder ".", "/vagrant", disabled: true
   config.vm.synced_folder "./themes", "/var/www/wp-content/themes", nfs: !is_windows, create: true
   config.vm.synced_folder "./plugins", "/var/www/wp-content/plugins", nfs: !is_windows, create: true

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,5 +23,8 @@ Vagrant.configure(2) do |config|
   config.vm.provision :puppet do |puppet|
     puppet.manifests_path = "puppet"
     puppet.module_path = "puppet/modules"
+    puppet.facter = {
+    	"quickstart_domain" => config.vm.hostname
+    }
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,8 @@
 
 Vagrant.configure(2) do |config|
   config.vm.box = "ubuntu/trusty64"
-  config.vm.hostname = "vip.local"
+  # todo: check the resultant hostname is valid, e.g. no spaces
+  config.vm.hostname = File.basename( File.dirname(__FILE__) ) + ".vip.local"
   config.vm.network "private_network", type: "dhcp"
 
 # define is_windows used for determinig whether we should or not use nfs

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,8 +7,8 @@ Vagrant.configure(2) do |config|
   config.vm.hostname = File.basename( File.dirname(__FILE__) ) + ".vip.local"
   config.vm.network "private_network", type: "dhcp"
 
-# define is_windows used for determinig whether we should or not use nfs
-# todo: use samba for windows?
+  # define is_windows used for determining whether we should or not use nfs
+  # todo: use samba for windows?
   is_windows = RUBY_PLATFORM.downcase.include?("w32");
 
   config.vm.synced_folder ".", "/vagrant", disabled: true

--- a/puppet/default.pp
+++ b/puppet/default.pp
@@ -8,7 +8,11 @@ include apt::backports
 
 Class['apt::update'] -> Package <||>
 
-host { 'vip.local': ip => '127.0.0.1' }
+host { 'vip.local': 
+    name => $quickstart_domain,
+    ensure => 'present',
+    ip => '127.0.0.1',
+}
 
 package { ['git']:
 	ensure => present,

--- a/puppet/manifests/env.pp
+++ b/puppet/manifests/env.pp
@@ -1,0 +1,3 @@
+
+# Set up Zeroconf (Bonjour)
+package { 'libnss-mdns': ensure => present }

--- a/puppet/manifests/nginx.pp
+++ b/puppet/manifests/nginx.pp
@@ -2,6 +2,7 @@ class { nginx: }
 
 nginx::resource::vhost { 'vip.local':
 	www_root             => '/var/www',
+	server_name          => [$quickstart_domain],
 	index_files          => ['index.php'],
 	raw_prepend          => 'try_files $uri $uri/ /index.php;',
 	use_default_location => false,

--- a/puppet/manifests/wordpress.pp
+++ b/puppet/manifests/wordpress.pp
@@ -20,7 +20,7 @@ exec { 'find /var/www -not -path "*wp-content/themes*" -not -path "*wp-content/p
 	user	=> 'root',
 } ->
 wp::site { '/var/www':
-	url            => 'http://vip.local',
+	url            => "http://${quickstart_domain}",
 	name           => 'VIP',
 	admin_user     => 'wordpress',
 	admin_password => 'wordpress',


### PR DESCRIPTION
- Have Vagrant use DHCP to dynamically assign the IP address for the VM
- Dynamically assign the `config.vm.hostname` by prefixing the name of the folder containing the `Vagrantfile`
- Use Facter to pass the (dynamic) `config.vm.hostname` into Puppet as `$quickstart_domain` for use in manifests
- Use Bonjour/Zeroconf to assign "DNS" to the domain without needing to edit `/etc/hosts`

See the Zeroconf note here: https://github.com/Automattic/vip-quickstart/issues/240#issuecomment-51095993
