### PR TITLE
Set PHP error log

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,11 @@ cd /var/www
 
 ## Viewing logs
 
-The PHP log is written to `/var/log/nginx/vip.local.error.log` on the guest machine. Once you have your Vagrant running (see above), you can view the log as follows:
+The PHP log is written to `/var/log/php/error.log` on the guest machine. Once you have your Vagrant running (see above), you can view the log as follows:
 
 ```bash
 vagrant ssh
-less +F /var/log/nginx/vip.local.error.log
+less +F /var/log/php/error.log
 ```
 
 N.B. The `less +F` command and option starts following the log file in the `less` file viewer, with new lines being appended as they are written to the log. To stop following the log, i.e. to stop new lines being appended in `less`, you can type `ctrl+c`, and to start again, you can type `F`.

--- a/puppet/manifests/php.pp
+++ b/puppet/manifests/php.pp
@@ -2,4 +2,23 @@ class { 'php':
 	service => 'nginx',
 }
 
-php::module { ['fpm','cli','mysql']: }
+service { 'php5-fpm':
+    ensure => running,
+    enable => true,
+}
+
+php::module { ['fpm','cli','mysql']: } ->
+file { '/var/log/php/' :
+  ensure => directory,
+  owner => www-data, group => www-data, mode => 444,
+} ->
+file { '/var/log/php/error.log' :
+  ensure => present,
+  owner => www-data, group => www-data, mode => 644,
+} ->
+file { '/etc/php5/fpm/conf.d/error.ini' :
+  ensure => present,
+  notify  => Service['php5-fpm'],
+  owner => root, group => root, mode => 644,
+  content => "error_log = /var/log/php/error.log\n",
+}


### PR DESCRIPTION
Creates the directory for the log file, creates the log file with the right owner and permissions, sets PHP to log to the error log file.
