### PR TITLE
Fix content-cleanup errors that block init

### DIFF
--- a/puppet/manifests/wordpress.pp
+++ b/puppet/manifests/wordpress.pp
@@ -60,12 +60,12 @@ exec { "[ -d ${theme} ] && /usr/bin/wp --allow-root theme activate ${theme} || e
 	cwd => '/var/www/wp-content/themes',
 	user => 'root',
 } ->
-exec { "[ ! $(/usr/bin/wp --allow-root post list --post_type='post' --format=ids) ] || /usr/bin/wp --allow-root post delete --force $(/usr/bin/wp --allow-root post list --post_type='post' --format=ids)":
+exec { "[ ! $(/usr/bin/wp --allow-root post list --post_type='post' --post_status=any --format=ids) ] || /usr/bin/wp --allow-root post delete --force $(/usr/bin/wp --allow-root post list --post_type='post' --post_status=any --format=ids)":
 	require => Wp::Site['/var/www'],
 	cwd     => '/var/www',
 	user    => 'root'
 } ->
-exec { "[ ! $(/usr/bin/wp --allow-root post list --post_type='page' --format=ids) ] || /usr/bin/wp --allow-root post delete --force $(/usr/bin/wp --allow-root post list --post_type='page' --format=ids)":
+exec { "[ ! $(/usr/bin/wp --allow-root post list --post_type='page' --post_status=any --format=ids) ] || /usr/bin/wp --allow-root post delete --force $(/usr/bin/wp --allow-root post list --post_type='page' --post_status=any --format=ids)":
 	require => Wp::Site['/var/www'],
 	cwd     => '/var/www',
 	user    => 'root'

--- a/puppet/manifests/wordpress.pp
+++ b/puppet/manifests/wordpress.pp
@@ -60,12 +60,12 @@ exec { "[ -d ${theme} ] && /usr/bin/wp --allow-root theme activate ${theme} || e
 	cwd => '/var/www/wp-content/themes',
 	user => 'root',
 } ->
-exec { "/usr/bin/wp --allow-root post delete $(/usr/bin/wp --allow-root post list --post_type='post' --format=ids)":
+exec { "/usr/bin/wp --allow-root post delete --force $(/usr/bin/wp --allow-root post list --post_type='post' --format=ids)":
 	require => Wp::Site['/var/www'],
 	cwd     => '/var/www',
 	user    => 'root'
 } ->
-exec { "/usr/bin/wp --allow-root post delete $(/usr/bin/wp --allow-root post list --post_type='page' --format=ids)":
+exec { "/usr/bin/wp --allow-root post delete --force $(/usr/bin/wp --allow-root post list --post_type='page' --format=ids)":
 	require => Wp::Site['/var/www'],
 	cwd     => '/var/www',
 	user    => 'root'

--- a/puppet/manifests/wordpress.pp
+++ b/puppet/manifests/wordpress.pp
@@ -60,12 +60,12 @@ exec { "[ -d ${theme} ] && /usr/bin/wp --allow-root theme activate ${theme} || e
 	cwd => '/var/www/wp-content/themes',
 	user => 'root',
 } ->
-exec { "/usr/bin/wp --allow-root post delete --force $(/usr/bin/wp --allow-root post list --post_type='post' --format=ids)":
+exec { "[ ! $(/usr/bin/wp --allow-root post list --post_type='post' --format=ids) ] || /usr/bin/wp --allow-root post delete --force $(/usr/bin/wp --allow-root post list --post_type='post' --format=ids)":
 	require => Wp::Site['/var/www'],
 	cwd     => '/var/www',
 	user    => 'root'
 } ->
-exec { "/usr/bin/wp --allow-root post delete --force $(/usr/bin/wp --allow-root post list --post_type='page' --format=ids)":
+exec { "[ ! $(/usr/bin/wp --allow-root post list --post_type='page' --format=ids) ] || /usr/bin/wp --allow-root post delete --force $(/usr/bin/wp --allow-root post list --post_type='page' --format=ids)":
 	require => Wp::Site['/var/www'],
 	cwd     => '/var/www',
 	user    => 'root'


### PR DESCRIPTION
As reported in #24, the same init command (without `--up`) called twice would cause init to fail. The cause was two issues combining to cause Puppet's init to fail.

First, when content was "deleted" during init to prepare for import, it was really only moved to the trash. As a result, the importer would skip the sample posts because both still existed, they just weren't published. This left the WP site without any published content.

Second, if there was no published content to delete, the delete commands would fail and leave the site without any published posts due to the aforementioned error.

Both #20 and #24 are fixed with this PR.
