### PR TITLE
Fail for bad parameters

### DIFF
--- a/qs-init.sh
+++ b/qs-init.sh
@@ -77,7 +77,8 @@ while :; do
             ;;
 
         *)
-           break
+			echo "\n\nERROR: Unknown parameter or bad parameter value detected: $1 $2\n"
+			exit 1
     esac
 
     shift

--- a/qs-init.sh
+++ b/qs-init.sh
@@ -17,6 +17,8 @@ theme=0
 wxr=0
 needs_to_up=0
 
+# This while loop will go forever until we break out of it or exit, 
+# as the : operator aliases to `true`.
 while :; do
     case $1 in
         --client)

--- a/qs-init.sh
+++ b/qs-init.sh
@@ -79,8 +79,11 @@ while :; do
             ;;
 
         *)
-			echo "\n\nERROR: Unknown parameter or bad parameter value detected: $1 $2\n"
-			exit 1
+            if [ "$1" ]; then
+				echo "\n\nERROR: Unknown parameter or bad parameter value detected: $1 $2\n"
+				exit 1
+            fi
+            break
     esac
 
     shift


### PR DESCRIPTION
If we get a bad parameter, exit non-zero with a user message
