### PR TITLE
Pass query string to nginx try_files

### DIFF
--- a/puppet/manifests/nginx.pp
+++ b/puppet/manifests/nginx.pp
@@ -4,7 +4,7 @@ nginx::resource::vhost { $client:
 	www_root             => '/var/www',
 	server_name          => [$fqdn],
 	index_files          => ['index.php'],
-	raw_prepend          => 'try_files $uri $uri/ /index.php;',
+	raw_prepend          => 'try_files $uri $uri/ /index.php?$query_string;',
 	use_default_location => false,
 }
 


### PR DESCRIPTION
Hi VIP team! So I heard the "unstable" disclaimer loud and clear but was working with it today and noticed that that nginx wasn't passing the query string to PHP. Checked `/etc/nginx/sites-available/{site}.conf`. I'm not a puppet master, but pretty sure this pull request should fix that issue. Please let me know if this is invalid and if nginx is working as expected so I can try to track down why `$_SERVER['QUERY_STRING']` is empty. Thanks.
