### PR TITLE
Upgrade to PHP 7 ahead of production.

### DIFF
--- a/puppet/default.pp
+++ b/puppet/default.pp
@@ -6,7 +6,17 @@ include apt
 include apt::update
 include apt::backports
 
-Class['apt::update'] -> Package <||>
+# Make sure apt-get is up-to-date before we do anything else
+stage { 'updates': before => Stage['main'] }
+class { 'updates': stage  => updates }
+
+# updates
+class updates {
+	exec { 'apt-get update':
+		command   => 'apt-get update --quiet --yes',
+		timeout => 0
+	}
+}
 
 host { 'vip-go':
     name => $hostname,

--- a/puppet/manifests/nginx.pp
+++ b/puppet/manifests/nginx.pp
@@ -11,7 +11,7 @@ nginx::resource::vhost { $client:
 nginx::resource::location { 'php':
 	location => '~ \.php$',
 	vhost    => $client,
-	fastcgi  => 'unix:/var/run/php5-fpm.sock',
+	fastcgi  => 'unix:/var/run/php/php7.0-fpm.sock',
 	fastcgi_param      => {
 		'SCRIPT_FILENAME' => '$document_root$fastcgi_script_name',
 	}
@@ -19,7 +19,7 @@ nginx::resource::location { 'php':
 
 nginx::resource::location { '/_static/':
 	vhost   => $client,
-	fastcgi => 'unix:/var/run/php5-fpm.sock',
+	fastcgi => 'unix:/var/run/php/php7.0-fpm.sock',
 	fastcgi_param => {
 		'SCRIPT_FILENAME' => '$document_root/wp-content/mu-plugins/http-concat/ngx-http-concat.php',
 	}

--- a/puppet/manifests/php.pp
+++ b/puppet/manifests/php.pp
@@ -1,13 +1,19 @@
+apt::ppa { 'ppa:ondrej/php': } ->
 class { 'php':
-	service => 'nginx',
+	package     => 'php7.0',
+	service     => 'nginx',
+	config_dir  => '/etc/php/7.0',
+	config_file => '/etc/php/7.0/apache2/php.ini',
 }
 
-service { 'php5-fpm':
+service { 'php7.0-fpm':
     ensure => running,
     enable => true,
 }
 
-php::module { ['fpm','cli','mysql']: } ->
+php::module { ['fpm','cli','mysql']:
+	module_prefix => 'php7.0-'
+} ->
 file { '/var/log/php/' :
   ensure => directory,
   owner => www-data, group => www-data, mode => 444,
@@ -16,9 +22,9 @@ file { '/var/log/php/error.log' :
   ensure => present,
   owner => www-data, group => www-data, mode => 644,
 } ->
-file { '/etc/php5/fpm/conf.d/error.ini' :
+file { '/etc/php/7.0/fpm/conf.d/error.ini' :
   ensure => present,
-  notify  => Service['php5-fpm'],
+  notify  => Service['php7.0-fpm'],
   owner => root, group => root, mode => 644,
   content => "error_log = /var/log/php/error.log\n",
 }


### PR DESCRIPTION
Upgrade Quickstart to PHP 7 ahead of production so devs can
test in their local environments.
