### PR TITLE
syntax error in qs-init.sh

### DIFF
--- a/qs-init.sh
+++ b/qs-init.sh
@@ -110,6 +110,7 @@ while :; do
 		--help)
 			usage
 			exit
+			;;
 
 		*)
 			if [ "$1" ]; then


### PR DESCRIPTION
I had to add this to get bash to run the init script properly. Not sure if it's a version-dependent issue; my version is `GNU bash, version 3.2.57(1)-release (x86_64-apple-darwin14)`
